### PR TITLE
HDM-1166 Adding Camel routes to create and update jobs in the database via JPA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,11 @@
 		</dependency>
 		<dependency>
 		  <groupId>org.apache.camel</groupId>
+		  <artifactId>camel-jpa</artifactId>
+		  <version>${camel.version}</version>
+		</dependency>
+		<dependency>
+		  <groupId>org.apache.camel</groupId>
 		  <artifactId>camel-jackson</artifactId>
 		  <version>${camel.version}</version>
 		</dependency>

--- a/src/main/java/org/fcrepo/camel/external/storage/Application.java
+++ b/src/main/java/org/fcrepo/camel/external/storage/Application.java
@@ -3,7 +3,6 @@ package org.fcrepo.camel.external.storage;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.servlet.CamelHttpTransportServlet;
 import org.apache.camel.model.rest.RestBindingMode;
-import org.fcrepo.camel.external.storage.service.DatabaseService;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
@@ -36,13 +35,8 @@ public class Application {
 	            .bindingMode(RestBindingMode.json)
 	            .dataFormatProperty("prettyPrint", "true")
 	            .apiContextPath("/api-doc")
-	                .apiProperty("api.title", "User API").apiProperty("api.version", "1.0.0")
+	                .apiProperty("api.title", "External Storage Proxy API").apiProperty("api.version", "v1.0.0.beta1")
 	                .apiProperty("cors", "true");
-	            rest("/jobs").description("Jobs REST service")
-	                .get("/").description("The list of all jobs performed on an external object")
-	                    .route().routeId("jobs-api")
-	                    .bean(DatabaseService.class, "findJobs")
-	                    .endRest();
 	        }
 	}
 }

--- a/src/main/java/org/fcrepo/camel/external/storage/model/Job.java
+++ b/src/main/java/org/fcrepo/camel/external/storage/model/Job.java
@@ -6,10 +6,14 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.NamedQuery;
 import javax.persistence.Table;
+
+import org.apache.camel.component.jpa.Consumed;
 
 @Entity
 @Table(name = "jobs")
+@NamedQuery(name = "readyJobs", query = "select j from Job j where j.status = 'waiting'")
 public class Job {
     @Id
     @GeneratedValue(strategy=GenerationType.AUTO)
@@ -22,11 +26,9 @@ public class Job {
     private String status;
     private Date created_at;
     private Date updated_at;
-    private String download_url;
+    private String result;
     private String type;
-    private String checksum;
     private String vendor_msg;
-
     
     public Long getId() {
         return id;
@@ -74,30 +76,31 @@ public class Job {
     public void setUpdated_at(Date updated_at) {
         this.updated_at = updated_at;
     }
-    public String getDownload_url() {
-        return download_url;
+    public String getResult() {
+        return result;
     }
-    public void setDownload_url(String download_url) {
-        this.download_url = download_url;
+
+    public void setResult(String result) {
+        this.result = result;
     }
+
     public String getType() {
         return type;
     }
     public void setType(String type) {
         this.type = type;
     }
-    public String getChecksum() {
-        return checksum;
-    }
-    public void setChecksum(String checksum) {
-        this.checksum = checksum;
-    }
+
     public String getVendor_msg() {
         return vendor_msg;
     }
     public void setVendor_msg(String vendor_msg) {
         this.vendor_msg = vendor_msg;
     }
-
-
+    
+    @Consumed
+    public void afterConsume()
+    {
+        setStatus("queued");
+    }
 }

--- a/src/main/java/org/fcrepo/camel/external/storage/service/DatabaseService.java
+++ b/src/main/java/org/fcrepo/camel/external/storage/service/DatabaseService.java
@@ -14,4 +14,12 @@ public class DatabaseService {
     public Iterable<Job> findJobs() {
         return jobs.findAll();
     }
+    
+    public Job generateJob(String file_uri, String service) {
+        Job job = new Job();
+        job.setExternal_uri(file_uri);
+        job.setService(service);
+        job.setStatus("waiting");
+        return job;
+    }
 }

--- a/src/main/resources/external-storage-proxy.xml
+++ b/src/main/resources/external-storage-proxy.xml
@@ -46,6 +46,15 @@
     
 
     <!-- Public API routes -->
+    
+    
+    <!-- A dummy post route for test suite -->
+    <route id="begin_dummyService_stage">
+      <from uri="direct:begin_dummyService_stage"/>
+      <to uri="bean:database_service?method=generateJob(${header.external_uri}, ${header.service})"/>
+      <to uri="jpa://org.fcrepo.camel.external.storage.model.Job"/>
+      <to uri="direct:log_request"/>
+    </route>
 
     <route id="begin_sda_status">
       <from uri="direct:begin_sda_status"/>

--- a/src/main/resources/external-storage-proxy.xml
+++ b/src/main/resources/external-storage-proxy.xml
@@ -27,6 +27,11 @@
       </get>
     </rest>
 
+    <route id="job_queue_processor">
+      <from uri="jpa://org.fcrepo.camel.external.storage.model.Job?consumer.namedQuery=readyJobs&amp;consumer.delay=10000&amp;consumeDelete=false" />
+      <to uri="direct:log_request"/>
+    </route>
+    
     <route id="status_header">
       <from uri="direct:status_header"/>
       <setHeader headerName="action"><constant>status</constant></setHeader>

--- a/src/main/resources/external-storage-proxy.xml
+++ b/src/main/resources/external-storage-proxy.xml
@@ -8,6 +8,7 @@
   
   <bean id="defaultProcessor" class="org.fcrepo.camel.external.storage.provider.sda.DefaultProcessor"/>
   <bean id="sda_proxy_routes" class="org.fcrepo.camel.external.storage.provider.sda.StorageProxyRouter"/>
+  <bean id="database_service" class="org.fcrepo.camel.external.storage.service.DatabaseService"/>
   
   <camelContext id="ExternalStorageProxy" xmlns="http://camel.apache.org/schema/spring">
     <routeBuilder ref="sda_proxy_routes" />
@@ -20,6 +21,10 @@
       <post uri="/{service}/stage/{external_uri}">
         <to uri="direct:stage_header"/>
       </post>
+      
+      <get uri="/jobs">
+        <to uri="bean:database_service?method=findJobs"/>
+      </get>
     </rest>
 
     <route id="status_header">
@@ -33,6 +38,7 @@
       <setHeader headerName="action"><constant>stage</constant></setHeader>
       <toD uri="direct:begin_${header.service}_stage"/>
     </route>
+    
 
     <!-- Public API routes -->
 

--- a/src/test/java/org/fcrepo/camel/external/storage/ApplicationTest.java
+++ b/src/test/java/org/fcrepo/camel/external/storage/ApplicationTest.java
@@ -33,7 +33,7 @@ public class ApplicationTest {
     private TestRestTemplate restTemplate;
 
     @Test
-    public void jobsTest() {
+    public void getJobsTest() {
         ResponseEntity<List<Job>> response = restTemplate.exchange("/jobs",
             HttpMethod.GET, null, new ParameterizedTypeReference<List<Job>>() {
             });
@@ -49,6 +49,7 @@ public class ApplicationTest {
     }
     
     @Test
+    // @Ignore
      public void jobQueueProcessorTest() {
         // Wait for the job_queue_processor route to consume/alter the db rows
         try {
@@ -64,5 +65,19 @@ public class ApplicationTest {
            will be changed. */
         assertThat(jobs).element(0)
             .hasFieldOrPropertyWithValue("status", "queued");
+    }
+    
+    @Test
+    // @Ignore
+    public void postJobTest() {
+        ResponseEntity<String> stageResponse = restTemplate.exchange("/dummyService/stage/unstagedFile",
+            HttpMethod.POST, null, String.class);
+        assertThat(stageResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        ResponseEntity<List<Job>> response = restTemplate.exchange("/jobs",
+            HttpMethod.GET, null, new ParameterizedTypeReference<List<Job>>() {});
+        List<Job> jobs = response.getBody();
+        assertThat(jobs).hasSize(3);
+        assertThat(jobs).element(2)
+            .hasFieldOrPropertyWithValue("external_uri", "unstagedFile");
     }
 }

--- a/src/test/java/org/fcrepo/camel/external/storage/ApplicationTest.java
+++ b/src/test/java/org/fcrepo/camel/external/storage/ApplicationTest.java
@@ -47,4 +47,22 @@ public class ApplicationTest {
             .hasFieldOrPropertyWithValue("external_uri", "myFile")
             .hasFieldOrPropertyWithValue("type","fixity");
     }
+    
+    @Test
+     public void jobQueueProcessorTest() {
+        // Wait for the job_queue_processor route to consume/alter the db rows
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        ResponseEntity<List<Job>> response = restTemplate.exchange("/jobs",
+            HttpMethod.GET, null, new ParameterizedTypeReference<List<Job>>() {
+            });
+        List<Job> jobs = response.getBody();
+        /* If the Camel JPA route is working, the status of selected rows in the database 
+           will be changed. */
+        assertThat(jobs).element(0)
+            .hasFieldOrPropertyWithValue("status", "queued");
+    }
 }

--- a/src/test/resources/afterTests.sql
+++ b/src/test/resources/afterTests.sql
@@ -1,3 +1,5 @@
 /* Add any post test cleanup
   SQL here
 */
+
+TRUNCATE TABLE jobs;

--- a/src/test/resources/beforeTests.sql
+++ b/src/test/resources/beforeTests.sql
@@ -1,4 +1,4 @@
 INSERT INTO jobs (id, external_uri, service, status, type)
   VALUES
-      (1, 'myFile', 'myService', 'success', 'stage'),
-      (2, 'myFile', 'myService', 'pending', 'fixity');
+      (1, 'myFile', 'myService', 'waiting', 'stage'),
+      (2, 'myFile', 'myService', 'waiting', 'fixity');


### PR DESCRIPTION
Using the camel-jpa component, this adds the ability to add a new job to the queue.  It also adds a timed JPA route that will consume the new ready jobs, redirect to appropriate routing, and mark them so that subsequent intervals know they have been consumed.

For testing and for a reference implementation, there is a Camel route to create a job called `begin_dummyService_stage` and is available at `POST /dummyService/stage/<file>`

The Camel route that is polling for ready jobs is `job_queue_processor`.  The status field gets updated after consumption via a callback to the method annotated with `@Consume` in the `Job` model.